### PR TITLE
Restore notebook examples for current OLS version

### DIFF
--- a/notebooks/ictv.ipynb
+++ b/notebooks/ictv.ipynb
@@ -10,19 +10,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 1,
    "id": "d7a03d72",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T12:54:35.460470Z",
+     "iopub.status.busy": "2026-06-23T12:54:35.460348Z",
+     "iopub.status.idle": "2026-06-23T12:54:35.775762Z",
+     "shell.execute_reply": "2026-06-23T12:54:35.775235Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2\n",
@@ -31,6 +29,15 @@
     "import json\n",
     "\n",
     "from ictv_ols import ICTVOLSClient\n",
+    "\n",
+    "\n",
+    "def show_table(df):\n",
+    "    try:\n",
+    "        print(df.to_markdown())\n",
+    "    except ImportError:\n",
+    "        print(df.to_string(index=False))\n",
+    "\n",
+    "\n",
     "client = ICTVOLSClient('https://www.ebi.ac.uk/ols4/api/v2/ontologies/ictv')"
    ]
   },
@@ -44,27 +51,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 2,
    "id": "3b0818bd",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T12:54:35.777306Z",
+     "iopub.status.busy": "2026-06-23T12:54:35.777138Z",
+     "iopub.status.idle": "2026-06-23T12:54:43.445707Z",
+     "shell.execute_reply": "2026-06-23T12:54:43.445215Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of viruses in MSL7: 1221\n",
-      "|    | msl   | ictv_id      | label                      |\n",
-      "|---:|:------|:-------------|:---------------------------|\n",
-      "|  0 | MSL7  | ICTV19710002 | Papovaviridae              |\n",
-      "|  1 | MSL7  | ICTV19710003 | Picornaviridae             |\n",
-      "|  2 | MSL7  | ICTV19710008 | Papillomavirus             |\n",
-      "|  3 | MSL7  | ICTV19710009 | Polyomavirus               |\n",
-      "|  4 | MSL7  | ICTV19710010 | Calicivirus                |\n",
-      "|  5 | MSL7  | ICTV19710011 | Enterovirus                |\n",
-      "|  6 | MSL7  | ICTV19710012 | Rhinovirus                 |\n",
-      "|  7 | MSL7  | ICTV19710013 | Mastadenovirus             |\n",
-      "|  8 | MSL7  | ICTV19710014 | Alfalfa mosaic virus group |\n",
-      "|  9 | MSL7  | ICTV19710015 | Alphavirus                 |\n"
+      "Number of viruses in MSL7: 1222\n",
+      " msl      ictv_id                      label\n",
+      "MSL7 ICTV19710002              Papovaviridae\n",
+      "MSL7 ICTV19710003             Picornaviridae\n",
+      "MSL7 ICTV19710008             Papillomavirus\n",
+      "MSL7 ICTV19710009               Polyomavirus\n",
+      "MSL7 ICTV19710010                Calicivirus\n",
+      "MSL7 ICTV19710012                 Rhinovirus\n",
+      "MSL7 ICTV19710013             Mastadenovirus\n",
+      "MSL7 ICTV19710014 Alfalfa mosaic virus group\n",
+      "MSL7 ICTV19710015                 Alphavirus\n",
+      "MSL7 ICTV19710016                 Flavivirus\n"
      ]
     }
    ],
@@ -74,7 +87,7 @@
     "print(f\"Number of viruses in MSL7: {len(msl_7_viruses)}\")\n",
     "\n",
     "df = pd.DataFrame(msl_7_viruses)[['msl', 'ictv_id', 'label']]\n",
-    "print(df.head(10).to_markdown())\n",
+    "show_table(df.head(10))\n",
     "\n"
    ]
   },
@@ -88,9 +101,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 3,
    "id": "732103ef",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T12:54:43.448047Z",
+     "iopub.status.busy": "2026-06-23T12:54:43.447933Z",
+     "iopub.status.idle": "2026-06-23T12:54:49.835622Z",
+     "shell.execute_reply": "2026-06-23T12:54:49.835079Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -112,7 +132,7 @@
       "    \"http://ictv.global/id/MSL8/ICTV19710003\"\n",
       "  ],\n",
       "  \"current_replacements\": [\n",
-      "    \"http://ictv.global/id/MSL40/ICTV19710003\"\n",
+      "    \"http://ictv.global/id/MSL41/ICTV19710003\"\n",
       "  ]\n",
       "}\n"
      ]
@@ -134,9 +154,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 4,
    "id": "2de8413c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T12:54:49.836985Z",
+     "iopub.status.busy": "2026-06-23T12:54:49.836860Z",
+     "iopub.status.idle": "2026-06-23T12:54:55.882329Z",
+     "shell.execute_reply": "2026-06-23T12:54:55.881931Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -174,9 +201,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 5,
    "id": "4d240432",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T12:54:55.883585Z",
+     "iopub.status.busy": "2026-06-23T12:54:55.883467Z",
+     "iopub.status.idle": "2026-06-23T12:54:57.825865Z",
+     "shell.execute_reply": "2026-06-23T12:54:57.825473Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -184,17 +218,11 @@
      "text": [
       "Obsolescence reason: SPLIT\n",
       "Replacements:\n",
-      "|    | msl   | ictv_id      | label                     |\n",
-      "|---:|:------|:-------------|:--------------------------|\n",
-      "|  0 | MSL17 | ICTV19810186 | Bovine adenovirus 4       |\n",
-      "|  1 | MSL17 | ICTV19810187 | Bovine adenovirus 5       |\n",
-      "|  2 | MSL17 | ICTV19810188 | Bovine adenovirus 6       |\n",
-      "|  3 | MSL17 | ICTV19810189 | Bovine adenovirus 7       |\n",
-      "|  4 | MSL17 | ICTV19810190 | Bovine adenovirus 8       |\n",
-      "|  5 | MSL40 | ICTV19810183 | Mastadenovirus bosprimum  |\n",
-      "|  6 | MSL40 | ICTV19810185 | Mastadenovirus bostertium |\n",
-      "|  7 | MSL40 | ICTV19990516 | Mastadenovirus caesari    |\n",
-      "|  8 | MSL40 | ICTV19990521 | Mastadenovirus bovidae    |\n"
+      "  msl      ictv_id                     label\n",
+      "MSL41 ICTV19810183  Mastadenovirus bosprimum\n",
+      "MSL41 ICTV19810185 Mastadenovirus bostertium\n",
+      "MSL41 ICTV19990516    Mastadenovirus caesari\n",
+      "MSL41 ICTV19990521    Mastadenovirus bovidae\n"
      ]
     }
    ],
@@ -205,7 +233,7 @@
     "print(f\"Obsolescence reason: {taxon['obsolescence_reason']}\")\n",
     "print(f\"Replacements:\")\n",
     "\n",
-    "print(pd.DataFrame(replacements)[['msl', 'ictv_id', 'label']].to_markdown())\n",
+    "show_table(pd.DataFrame(replacements)[['msl', 'ictv_id', 'label']])\n",
     "\n"
    ]
   },
@@ -219,26 +247,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 6,
    "id": "6634034f",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T12:54:57.827086Z",
+     "iopub.status.busy": "2026-06-23T12:54:57.826968Z",
+     "iopub.status.idle": "2026-06-23T12:54:59.424693Z",
+     "shell.execute_reply": "2026-06-23T12:54:59.424201Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "|    | msl   | ictv_id      | label              | obsolescence_reason   |\n",
-      "|---:|:------|:-------------|:-------------------|:----------------------|\n",
-      "|  0 | MSL17 | ICTV19710068 | Human poliovirus 1 | MERGED                |\n",
-      "|  1 | MSL17 | ICTV19790556 | Human poliovirus 2 | MERGED                |\n",
-      "|  2 | MSL17 | ICTV19790557 | Human poliovirus 3 | MERGED                |\n"
+      "  msl      ictv_id              label obsolescence_reason\n",
+      "MSL17 ICTV19790556 Human poliovirus 2              MERGED\n",
+      "MSL17 ICTV19790557 Human poliovirus 3              MERGED\n",
+      "MSL17 ICTV20083305 Human poliovirus 1              MERGED\n"
      ]
     }
    ],
    "source": [
     "parents = client.get_historical_parents('Poliovirus', 'MSL18')\n",
     "\n",
-    "print(pd.DataFrame(parents)[['msl', 'ictv_id', 'label', 'obsolescence_reason']].to_markdown())"
+    "show_table(pd.DataFrame(parents)[['msl', 'ictv_id', 'label', 'obsolescence_reason']])"
    ]
   },
   {
@@ -251,24 +285,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 7,
    "id": "91085263",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T12:54:59.426194Z",
+     "iopub.status.busy": "2026-06-23T12:54:59.426061Z",
+     "iopub.status.idle": "2026-06-23T12:55:00.152122Z",
+     "shell.execute_reply": "2026-06-23T12:55:00.151383Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "|    | msl   | ictv_id      | label           | obsolescence_reason   |\n",
-      "|---:|:------|:-------------|:----------------|:----------------------|\n",
-      "|  0 | MSL39 | ICTV19820133 | Cytorhabdovirus | SPLIT                 |\n"
+      "  msl      ictv_id           label obsolescence_reason\n",
+      "MSL39 ICTV19820133 Cytorhabdovirus               SPLIT\n"
      ]
     }
    ],
    "source": [
     "parents = client.get_historical_parents('Alphacytorhabdovirus', 'MSL40')\n",
     "\n",
-    "print(pd.DataFrame(parents)[['msl', 'ictv_id', 'label', 'obsolescence_reason']].to_markdown())\n"
+    "show_table(pd.DataFrame(parents)[['msl', 'ictv_id', 'label', 'obsolescence_reason']])\n"
    ]
   },
   {
@@ -281,26 +321,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 8,
    "id": "b43e063c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T12:55:00.154022Z",
+     "iopub.status.busy": "2026-06-23T12:55:00.153765Z",
+     "iopub.status.idle": "2026-06-23T12:55:04.596150Z",
+     "shell.execute_reply": "2026-06-23T12:55:04.595534Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "|    | msl   | ictv_id       | label                |\n",
-      "|---:|:------|:--------------|:---------------------|\n",
-      "|  0 | MSL40 | ICTV202419770 | Alphacytorhabdovirus |\n",
-      "|  1 | MSL40 | ICTV202419771 | Betacytorhabdovirus  |\n",
-      "|  2 | MSL40 | ICTV202419772 | Gammacytorhabdovirus |\n"
+      "  msl       ictv_id                label\n",
+      "MSL41 ICTV202419770 Alphacytorhabdovirus\n",
+      "MSL41 ICTV202419771  Betacytorhabdovirus\n",
+      "MSL41 ICTV202419772 Gammacytorhabdovirus\n"
      ]
     }
    ],
    "source": [
     "replacements = client.get_current_replacements('Cytorhabdovirus', 'MSL39')\n",
     "\n",
-    "print(pd.DataFrame(replacements)[['msl', 'ictv_id', 'label']].to_markdown())"
+    "show_table(pd.DataFrame(replacements)[['msl', 'ictv_id', 'label']])"
    ]
   },
   {
@@ -321,9 +367,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 9,
    "id": "424bcdab",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T12:55:04.598258Z",
+     "iopub.status.busy": "2026-06-23T12:55:04.598116Z",
+     "iopub.status.idle": "2026-06-23T12:55:05.420154Z",
+     "shell.execute_reply": "2026-06-23T12:55:05.419727Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -350,24 +403,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 10,
    "id": "11e1061d",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T12:55:05.421340Z",
+     "iopub.status.busy": "2026-06-23T12:55:05.421210Z",
+     "iopub.status.idle": "2026-06-23T12:55:16.405871Z",
+     "shell.execute_reply": "2026-06-23T12:55:16.405102Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "|    | historical_name                               | current_replacement_label   | current_replacement_id   | current_replacement_msl   |\n",
-      "|---:|:----------------------------------------------|:----------------------------|:-------------------------|:--------------------------|\n",
-      "|  0 | Severe acute respiratory syndrome coronavirus | Betacoronavirus pandemicum  | ICTV20040588             | MSL40                     |\n",
-      "|  1 | Poliovirus type 1                             | Enterovirus coxsackiepol    | ICTV20083305             | MSL40                     |\n",
-      "|  2 | Entomopoxvirus                                | Alphaentomopoxvirus         | ICTV19910168             | MSL40                     |\n",
-      "|  3 | Entomopoxvirus                                | Betaentomopoxvirus          | ICTV19910169             | MSL40                     |\n",
-      "|  4 | Poxvirus                                      | Poxviridae                  | ICTV19740004             | MSL40                     |\n",
-      "|  5 | Cytorhabdovirus                               | Alphacytorhabdovirus        | ICTV202419770            | MSL40                     |\n",
-      "|  6 | Cytorhabdovirus                               | Betacytorhabdovirus         | ICTV202419771            | MSL40                     |\n",
-      "|  7 | Cytorhabdovirus                               | Gammacytorhabdovirus        | ICTV202419772            | MSL40                     |\n"
+      "                              historical_name  current_replacement_label current_replacement_id current_replacement_msl\n",
+      "Severe acute respiratory syndrome coronavirus Betacoronavirus pandemicum           ICTV20040588                   MSL41\n",
+      "                            Poliovirus type 1   Enterovirus coxsackiepol           ICTV20083305                   MSL41\n",
+      "                               Entomopoxvirus        Alphaentomopoxvirus           ICTV19910168                   MSL41\n",
+      "                               Entomopoxvirus         Betaentomopoxvirus           ICTV19910169                   MSL41\n",
+      "                                     Poxvirus                 Poxviridae           ICTV19740004                   MSL41\n",
+      "                              Cytorhabdovirus       Alphacytorhabdovirus          ICTV202419770                   MSL41\n",
+      "                              Cytorhabdovirus        Betacytorhabdovirus          ICTV202419771                   MSL41\n",
+      "                              Cytorhabdovirus       Gammacytorhabdovirus          ICTV202419772                   MSL41\n"
      ]
     }
    ],
@@ -393,7 +452,7 @@
     "            \"current_replacement_msl\": r['msl']\n",
     "        })\n",
     "\n",
-    "print(pd.DataFrame(results).to_markdown())\n",
+    "show_table(pd.DataFrame(results))\n",
     "\n"
    ]
   },
@@ -407,24 +466,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 11,
    "id": "78568cbd",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T12:55:16.407469Z",
+     "iopub.status.busy": "2026-06-23T12:55:16.407343Z",
+     "iopub.status.idle": "2026-06-23T12:55:27.845130Z",
+     "shell.execute_reply": "2026-06-23T12:55:27.844768Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "|    | historical_id   | current_replacement_label   | current_replacement_id   | current_replacement_msl   |\n",
-      "|---:|:----------------|:----------------------------|:-------------------------|:--------------------------|\n",
-      "|  0 | ICTV20040588    | Betacoronavirus pandemicum  | ICTV20040588             | MSL40                     |\n",
-      "|  1 | ICTV19710068    | Enterovirus coxsackiepol    | ICTV20083305             | MSL40                     |\n",
-      "|  2 | ICTV19740021    | Alphaentomopoxvirus         | ICTV19910168             | MSL40                     |\n",
-      "|  3 | ICTV19740021    | Betaentomopoxvirus          | ICTV19910169             | MSL40                     |\n",
-      "|  4 | ICTV19710040    | Poxviridae                  | ICTV19740004             | MSL40                     |\n",
-      "|  5 | ICTV19820133    | Alphacytorhabdovirus        | ICTV202419770            | MSL40                     |\n",
-      "|  6 | ICTV19820133    | Betacytorhabdovirus         | ICTV202419771            | MSL40                     |\n",
-      "|  7 | ICTV19820133    | Gammacytorhabdovirus        | ICTV202419772            | MSL40                     |\n"
+      "historical_id  current_replacement_label current_replacement_id current_replacement_msl\n",
+      " ICTV20040588 Betacoronavirus pandemicum           ICTV20040588                   MSL41\n",
+      " ICTV20083305   Enterovirus coxsackiepol           ICTV20083305                   MSL41\n",
+      " ICTV19740021        Alphaentomopoxvirus           ICTV19910168                   MSL41\n",
+      " ICTV19740021         Betaentomopoxvirus           ICTV19910169                   MSL41\n",
+      " ICTV19740004                 Poxviridae           ICTV19740004                   MSL41\n",
+      " ICTV19820133       Alphacytorhabdovirus          ICTV202419770                   MSL41\n",
+      " ICTV19820133        Betacytorhabdovirus          ICTV202419771                   MSL41\n",
+      " ICTV19820133       Gammacytorhabdovirus          ICTV202419772                   MSL41\n"
      ]
     }
    ],
@@ -432,9 +497,9 @@
     "\n",
     "historical_ids = [\n",
     "    'ICTV20040588',\n",
-    "    'ICTV19710068',\n",
+    "    'ICTV20083305',\n",
     "    'ICTV19740021',\n",
-    "    'ICTV19710040',\n",
+    "    'ICTV19740004',\n",
     "    'ICTV19820133'\n",
     "]\n",
     "\n",
@@ -450,7 +515,7 @@
     "            \"current_replacement_msl\": r['msl']\n",
     "        })\n",
     "\n",
-    "print(pd.DataFrame(results).to_markdown())"
+    "show_table(pd.DataFrame(results))"
    ]
   }
  ],

--- a/notebooks/ictv_ols.py
+++ b/notebooks/ictv_ols.py
@@ -1,167 +1,375 @@
+"""Compatibility helpers for the ICTV OLS notebook examples.
+
+The notebook keeps the historical example API from this module, while the
+implementation delegates normal lookup work to the maintained Python helper in
+``helpers/python/ictv-api.py``.
+"""
+
+from __future__ import annotations
+
+import gzip
+import re
+from importlib import util
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 import requests
-import urllib.parse
 
-VERSION_INFO = urllib.parse.quote("http://www.w3.org/2002/07/owl#versionInfo")
-IDENTIFIER = urllib.parse.quote("http://purl.org/dc/terms/identifier")
+VERSION_INFO = "http://www.w3.org/2002/07/owl#versionInfo"
+IDENTIFIER = "http://purl.org/dc/terms/identifier"
+SUBCLASS_OF = "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+WAS_REVISION_OF = "http://www.w3.org/ns/prov#wasRevisionOf"
+HAD_REVISION = "http://www.w3.org/ns/prov#hadRevision"
+REPLACED_BY = "http://purl.obolibrary.org/obo/IAO_0100001"
+OBSOLESCENCE_REASON = "http://purl.obolibrary.org/obo/IAO_0000225"
+LATEST_ONTOLOGY_METADATA = "https://www.ebi.ac.uk/ols4/api/ontologies/ictv"
 
-class ICTVOLSClient:
 
-    def __init__(self, base_url):
-        self.cache = {}
-        self.base_url = base_url.rstrip('/')
-        self.headers = {
-            "Accept": "application/json"
-        }
+def _helper_path() -> Path:
+    here = Path(__file__).resolve()
+    for candidate in (here.parent, *here.parents):
+        path = candidate / "helpers" / "python" / "ictv-api.py"
+        if path.exists():
+            return path
+    raise FileNotFoundError("Cannot locate helpers/python/ictv-api.py")
 
-    def _validate_release(self, release):
+
+def _load_helper():
+    path = _helper_path()
+    spec = util.spec_from_file_location("ictv_api_helper", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load ICTV helper from {path}")
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_helper = _load_helper()
+
+
+class ICTVOLSClient(_helper.ICTVOLSClient):
+    """Notebook-facing client preserving the original example method names."""
+
+    def __init__(self, base_url: str = "https://www.ebi.ac.uk/ols4/api/v2/ontologies/ictv"):
+        super().__init__(base_url)
+        self._release_entities: Optional[List[Dict[str, Any]]] = None
+        self._release_entities_by_iri: Dict[str, Dict[str, Any]] = {}
+
+    def _validate_release(self, release: str) -> None:
         if not isinstance(release, str):
             raise ValueError(f"Release must be a string, got {type(release)}")
-        if not release.startswith("MSL"):
-            raise ValueError(f"MSL must start with 'MSL', got {release}")
+        if not re.match(r"^MSL\d+$", release, flags=re.IGNORECASE):
+            raise ValueError(f"MSL must look like 'MSL7', got {release}")
 
-    def get_all_taxa_by_release(self, release):
-        self._validate_release(release)
-        return list(map(self._map_entity, self._get_all_merged([
-            f"{self.base_url}/classes?{VERSION_INFO}={release}&isObsolete=false",
-            f"{self.base_url}/classes?{VERSION_INFO}={release}&isObsolete=true",
-        ])))
+    def get_all_taxa_by_release(self, release: str) -> List[Dict[str, Any]]:
+        """Return all taxa for one ICTV release.
 
-    def get_taxon_by_release(self, id_or_label, release):
+        OLS v2 class responses contain ``owl:versionInfo``, but the live v2
+        endpoint currently does not reliably filter on that property as a query
+        parameter. We try the OLS filter first and fall back to the ontology file
+        advertised by the OLS metadata endpoint when needed.
+        """
         self._validate_release(release)
-        res = self._get_all_merged([
-            f"{self.base_url}/classes?{VERSION_INFO}={release}&isObsolete=false&{IDENTIFIER}={id_or_label}",
-            f"{self.base_url}/classes?{VERSION_INFO}={release}&isObsolete=false&label={id_or_label}",
-            f"{self.base_url}/classes?{VERSION_INFO}={release}&isObsolete=true&{IDENTIFIER}={id_or_label}",
-            f"{self.base_url}/classes?{VERSION_INFO}={release}&isObsolete=true&label={id_or_label}",
-        ])
-        if not res:
+        items = self._get_all_from_ols_release_filter(release)
+        if not items:
+            wanted = release.upper()
+            items = [e for e in self._load_release_entities() if str(e.get(VERSION_INFO, "")).upper() == wanted]
+        return sorted((self._map_entity(e) for e in items), key=lambda x: x.get("ictv_id") or "")
+
+    def get_taxon_by_release(self, id_or_label: str, release: str) -> Dict[str, Any]:
+        self._validate_release(release)
+        candidates = self._find_release_candidates(id_or_label, release)
+        if not candidates:
             raise ValueError(f"Taxon with identifier/label {id_or_label} not found in release {release}")
-        if len(res) > 1:
+        if len(candidates) > 1:
             raise ValueError(f"Multiple taxa found with identifier/label {id_or_label} in release {release}")
-        return self._map_entity( res[0] )
+        return self._map_entity(candidates[0])
 
-    def get_current_replacements(self, id_or_label, release=None):
-        if release != None:
+    def get_current_replacements(self, id_or_label: str, release: Optional[str] = None) -> List[Dict[str, Any]]:
+        if release is not None:
             taxon = self.get_taxon_by_release(id_or_label, release)
-            return self._resolve_iris(taxon['current_replacements'])
+            replacements = self._resolve_iris(taxon["current_replacements"])
+            return [r for r in replacements if not r["is_obsolete"]]
+
+        mapped = self._current_replacements_without_release(id_or_label)
+        return [self._legacy_from_mapped(m) for m in mapped]
+
+    def get_historical_parents(self, id_or_label: str, release: str) -> List[Dict[str, Any]]:
+        taxon = self.get_taxon_by_release(id_or_label, release)
+        return self._resolve_iris(taxon["replaces"])
+
+    def get_taxonomic_parents(self, id_or_label: str, release: str) -> List[Dict[str, Any]]:
+        taxon = self.get_taxon_by_release(id_or_label, release)
+        return self._resolve_iris(taxon["taxonomic_parents"])
+
+    def _get_all_from_ols_release_filter(self, release: str) -> List[Dict[str, Any]]:
+        page = 0
+        size = 1000
+        out: List[Dict[str, Any]] = []
+        while True:
+            data = self.ols("classes", {
+                VERSION_INFO: release,
+                "includeObsoleteEntities": "true",
+                "page": page,
+                "size": size,
+            })
+            batch = data.get("elements") or []
+            if not batch:
+                return []
+            if any(str(e.get(VERSION_INFO, "")).upper() != release.upper() for e in batch):
+                return []
+            out.extend(batch)
+            page += 1
+            if page >= int(data.get("totalPages") or 0):
+                return out
+
+    def _find_release_candidates(self, id_or_label: str, release: str) -> List[Dict[str, Any]]:
+        value = str(id_or_label).strip()
+        wanted_release = release.upper()
+        wanted_text = self.normText(value)
+        candidates: List[Dict[str, Any]] = []
+
+        if self.isIctvId(value):
+            iri = f"http://ictv.global/id/{release.upper()}/{value.upper()}"
+            direct = self.retrieveTaxonByIRI(iri)
+            if direct and self._entity_release(direct) == wanted_release and self.entityMatchesIctvId(direct, value):
+                candidates.append(direct)
+            for e in self.seekOntologyTaxonByClassId(value):
+                full = self._full_entity(e)
+                if self._entity_release(full) == wanted_release and self.entityMatchesIctvId(full, value):
+                    candidates.append(full)
         else:
-            not_obsolete = self._get_all_merged([
-                f"{self.base_url}/classes?isObsolete=false&{IDENTIFIER}={id_or_label}",
-                f"{self.base_url}/classes?isObsolete=false&label={id_or_label}",
-            ])
-            if len(not_obsolete) > 0:
-                return [self._map_entity( not_obsolete[0] )]
-            obsolete = self._get_all_merged([
-                f"{self.base_url}/classes?isObsolete=true&{IDENTIFIER}={id_or_label}",
-                f"{self.base_url}/classes?isObsolete=true&label={id_or_label}",
-            ])
-            if len(obsolete) > 0:
-                replacement_iris = self._map_entity(obsolete[0])['current_replacements']
-                replacements = self._resolve_iris(replacement_iris)
-                replacements = [r for r in replacements if r['is_obsolete'] != True]
-                return replacements
+            for e in self._seek_exact_label(value, include_obsolete="true"):
+                full = self._full_entity(e)
+                if self._entity_release(full) == wanted_release and self.normText(self.normalizeValue(full.get("label"))) == wanted_text:
+                    candidates.append(full)
+
+        if not candidates:
+            for e in self._load_release_entities():
+                if self._entity_release(e) != wanted_release:
+                    continue
+                if self.isIctvId(value) and self.entityMatchesIctvId(e, value):
+                    candidates.append(e)
+                elif self.normText(self.normalizeValue(e.get("label"))) == wanted_text:
+                    candidates.append(e)
+
+        return self._dedupe_raw_by_iri(candidates)
+
+    def _current_replacements_without_release(self, id_or_label: str) -> List[Dict[str, Any]]:
+        for candidates in self._exact_candidate_groups(str(id_or_label)):
+            mapped = self._resolve_candidate_group_to_current(candidates)
+            if mapped:
+                return mapped
+
+        res = self.resolveToLatest(id_or_label, {
+            "replacements": True,
+            "enrichLineage": False,
+            "suggestions": False,
+        })
+        mapped = self._mapped_replacements_from_result(res)
+        if mapped:
+            return [m for m in mapped if not m.get("is_obsolete")]
+
+        return []
+
+    def _exact_candidate_groups(self, value: str) -> List[List[Dict[str, Any]]]:
+        if self.isIctvId(value):
+            return [self._seek_exact_id(value), self._seek_exact_id_from_release_file(value)]
+        return [
+            self._seek_exact_label(value, include_obsolete="false"),
+            self._seek_exact_label(value, include_obsolete="true"),
+            self._seek_exact_synonym(value),
+        ]
+
+    def _resolve_candidate_group_to_current(self, candidates: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        candidates = [self._full_entity(c) for c in self._dedupe_raw_by_iri(candidates)]
+        if not candidates:
             return []
 
-    def get_historical_parents(self, id_or_label, release=None):
-        taxon = self.get_taxon_by_release(id_or_label, release)
-        return self._resolve_iris(taxon['replaces'])
+        current = [self.mapEntity(c) for c in candidates if not c.get("isObsolete")]
+        if current:
+            return sorted(current, key=lambda x: self.parseMsl(x.get("msl")), reverse=True)
 
-    def get_taxonomic_parents(self, id_or_label, release=None):
-        taxon = self.get_taxon_by_release(id_or_label, release)
-        return self._resolve_iris(taxon['taxonomic_parents'])
+        for candidate in self.sortCandidates(candidates):
+            mapped = self.mapEntity(candidate)
+            replacements = self.followReplacements(mapped, {"replacements": True, "enrichLineage": False})
+            replacements = [r for r in replacements if not r.get("is_obsolete")]
+            if replacements:
+                return replacements
+            direct = [r for r in self._resolve_iris(self._legacy_from_mapped(mapped, raw=candidate)["current_replacements"]) if not r["is_obsolete"]]
+            if direct:
+                return [self._mapped_from_legacy(r) for r in direct]
+        return []
 
+    def _seek_exact_id(self, value: str) -> List[Dict[str, Any]]:
+        return [self._full_entity(e) for e in self.seekOntologyTaxonByClassId(value) if self.entityMatchesIctvId(e, value)]
 
+    def _seek_exact_id_from_release_file(self, value: str) -> List[Dict[str, Any]]:
+        return [e for e in self._load_release_entities() if self.entityMatchesIctvId(e, value)]
 
+    def _seek_exact_label(self, value: str, include_obsolete: str) -> List[Dict[str, Any]]:
+        wanted = self.normText(value)
+        return [
+            self._full_entity(e)
+            for e in (self.seekOntologyTaxon("classes", {
+                "search": value,
+                "searchFields": "label",
+                "exactMatch": "true",
+                "includeObsoleteEntities": include_obsolete,
+                "size": 100,
+            }) or [])
+            if self.normText(self.normalizeValue(e.get("label"))) == wanted
+        ]
 
+    def _seek_exact_synonym(self, value: str) -> List[Dict[str, Any]]:
+        return [self._full_entity(e) for e in self.seekOntologyTaxonBySynonym(value)]
 
-    def _get_all_merged(self, urls):
-        results = []
-        for url in urls:
-            results.extend(self._get_all(url))
-        return results
+    def _mapped_replacements_from_result(self, res: Dict[str, Any]) -> List[Dict[str, Any]]:
+        if res.get("status") == "current" and res.get("current"):
+            return [res["current"]]
+        if res.get("status") == "obsolete":
+            if res.get("replacements"):
+                return res["replacements"]
+            if res.get("final"):
+                return [res["final"]]
+        return []
 
-    def _get_all(self, url): 
-        if url in self.cache:
-            return self.cache[url]
-        else:
-            results = []
-            page = 0
-            while True:
-                response = requests.get(url, params={"page": page, "size": 1000})
-                if response.status_code != 200:
-                    raise Exception(f"Failed to retrieve data: {response.status_code}")
-                data = response.json()
-                elements = data.get("elements", [])
-                results.extend(elements)
-                page += 1
-                if page > data.get("totalPages", 0):
-                    break
-            self.cache[url] = results
-            return results
+    def _resolve_iris(self, iris: List[str]) -> List[Dict[str, Any]]:
+        resolved: List[Dict[str, Any]] = []
+        for iri in iris:
+            raw = self.retrieveTaxonByIRI(iri) or self._load_release_entities_by_iri().get(iri)
+            if raw:
+                resolved.append(self._map_entity(raw))
+        return resolved
 
-    def _map_entity(self, entity):
+    def _full_entity(self, entity: Dict[str, Any]) -> Dict[str, Any]:
+        iri = entity.get("iri")
+        return self.retrieveTaxonByIRI(iri) or entity if iri else entity
+
+    def _mapped_from_legacy(self, legacy: Dict[str, Any]) -> Dict[str, Any]:
         return {
-            "msl": entity["http://www.w3.org/2002/07/owl#versionInfo"],
-            "ictv_id": entity["http://purl.org/dc/terms/identifier"],
-            "label": self._ensure_list(entity, "label")[0],
-            "is_obsolete": entity.get("isObsolete", False),
-            "obsolescence_reason": self._map_obsolescence_reason( entity.get("http://purl.obolibrary.org/obo/IAO_0000225", None) ),
-            "taxonomic_parents": self._ensure_list(entity, "http://www.w3.org/2000/01/rdf-schema#subClassOf"),
-            "replaces": self._ensure_list(entity, "http://www.w3.org/ns/prov#wasRevisionOf"),
-            "replaced_by": self._ensure_list(entity, "http://www.w3.org/ns/prov#hadRevision"),
-            "current_replacements" : self._ensure_list(entity, "http://purl.obolibrary.org/obo/IAO_0100001"),
+            "msl": legacy.get("msl"),
+            "ictv_id": legacy.get("ictv_id"),
+            "label": legacy.get("label"),
+            "is_obsolete": legacy.get("is_obsolete", False),
+            "obsolescence_reason": legacy.get("obsolescence_reason"),
+            "direct_parent_iri": (legacy.get("taxonomic_parents") or [None])[0],
+            "was_revision_of": legacy.get("replaces"),
+            "had_revision": legacy.get("replaced_by"),
+            "replaced_by": legacy.get("current_replacements"),
         }
 
-    def _map_obsolescence_reason(self, reason):
-        if reason == 'http://purl.obolibrary.org/obo/IAO_0000229':
-            return 'SPLIT'
-        elif reason == 'http://purl.obolibrary.org/obo/IAO_0000227':
-            return 'MERGED'
-        else:
+    def _map_entity(self, entity: Dict[str, Any]) -> Dict[str, Any]:
+        mapped = self.mapEntity(entity)
+        return self._legacy_from_mapped(mapped, raw=entity)
+
+    def _legacy_from_mapped(self, mapped: Dict[str, Any], raw: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        raw = raw or {}
+        direct_parent = mapped.get("direct_parent_iri") or self.normalizeValue(raw.get(SUBCLASS_OF))
+        return {
+            "msl": mapped.get("msl"),
+            "ictv_id": mapped.get("ictv_id"),
+            "label": mapped.get("label"),
+            "is_obsolete": bool(mapped.get("is_obsolete")),
+            "obsolescence_reason": mapped.get("obsolescence_reason"),
+            "taxonomic_parents": self.toIriArray(direct_parent),
+            "replaces": self.toIriArray(mapped.get("was_revision_of") or raw.get(WAS_REVISION_OF)),
+            "replaced_by": self.toIriArray(mapped.get("had_revision") or raw.get(HAD_REVISION)),
+            "current_replacements": self.toIriArray(mapped.get("replaced_by") or raw.get(REPLACED_BY)),
+        }
+
+    def _entity_release(self, entity: Dict[str, Any]) -> str:
+        return str(entity.get(VERSION_INFO, "")).upper()
+
+    def _dedupe_raw_by_iri(self, entities: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        seen = set()
+        out = []
+        for entity in entities:
+            iri = entity.get("iri")
+            if iri and iri in seen:
+                continue
+            if iri:
+                seen.add(iri)
+            out.append(entity)
+        return out
+
+    def _load_release_entities_by_iri(self) -> Dict[str, Dict[str, Any]]:
+        self._load_release_entities()
+        return self._release_entities_by_iri
+
+    def _load_release_entities(self) -> List[Dict[str, Any]]:
+        if self._release_entities is not None:
+            return self._release_entities
+
+        metadata = requests.get(LATEST_ONTOLOGY_METADATA, headers=self.headers, timeout=30).json()
+        file_url = (metadata.get("config") or {}).get("fileLocation")
+        if not file_url:
+            raise RuntimeError("OLS metadata does not expose an ontology fileLocation")
+
+        response = requests.get(file_url, headers=self.headers, timeout=120)
+        response.raise_for_status()
+        text = gzip.decompress(response.content).decode("utf-8")
+
+        entities = []
+        for match in re.finditer(r"(?:^|\n)<([^>]+)> a owl:Class ;\n(.*?)(?=\n\n<|\Z)", text, flags=re.S):
+            iri, block = match.groups()
+            entity = self._parse_turtle_class_block(iri, block)
+            if entity:
+                entities.append(entity)
+
+        self._release_entities = entities
+        self._release_entities_by_iri = {e["iri"]: e for e in entities if e.get("iri")}
+        return entities
+
+    def _parse_turtle_class_block(self, iri: str, block: str) -> Optional[Dict[str, Any]]:
+        label = self._ttl_literal(block, "rdfs:label")
+        ictv_id = self._ttl_literal(block, "dcterms:identifier")
+        release = self._ttl_literal(block, "owl:versionInfo")
+        if not (label and ictv_id and release):
             return None
 
-    def _double_encode(self, value):
-        return urllib.parse.quote(urllib.parse.quote(value))
+        parent_iris = self._ttl_iris(block, "rdfs:subClassOf")
+        was_revision_of = self._ttl_iris(block, "prov:wasRevisionOf")
+        had_revision = self._ttl_iris(block, "prov:hadRevision")
+        current_replacements = self._ttl_iris(block, "iao:0100001")
+        reason = self._ttl_prefixed_iri(block, "iao:0000225")
 
-    def _split_iri(self, iri):
-        parts = iri.split('/')
-        msl = parts[-2:][0]
-        ictv_id = parts[-1:][0]
-        return msl, ictv_id
+        return {
+            "iri": iri,
+            "label": label,
+            IDENTIFIER: ictv_id,
+            VERSION_INFO: release,
+            "isObsolete": "owl:deprecated true" in block,
+            SUBCLASS_OF: parent_iris,
+            "directParent": parent_iris[0] if parent_iris else None,
+            WAS_REVISION_OF: was_revision_of,
+            HAD_REVISION: had_revision,
+            REPLACED_BY: current_replacements,
+            OBSOLESCENCE_REASON: reason,
+        }
 
-    def _ensure_list(self, obj, key):
-        if key in obj:
-            value = obj[key]
-            if isinstance(value, list):
-                return value
-            elif isinstance(value, str):
-                return [value]
-            else:
-                return [str(value)]
-        else:
+    def _ttl_literal(self, block: str, predicate: str) -> Optional[str]:
+        match = re.search(rf"{re.escape(predicate)}\s+\"((?:[^\"\\]|\\.)*)\"", block)
+        if not match:
+            return None
+        return match.group(1).replace('\\"', '"')
+
+    def _ttl_iris(self, block: str, predicate: str) -> List[str]:
+        match = re.search(rf"{re.escape(predicate)}\s+(.+?)\s*;", block, flags=re.S)
+        if not match:
             return []
-    
-    def _resolve_iris(self, iris):
-        res = []
-        for parent in iris:
-            parent_msl, parent_ictv_id = self._split_iri(parent)
-            parent = self.get_taxon_by_release(parent_ictv_id, parent_msl)
-            res.append(parent)
-        return res
+        return re.findall(r"<([^>]+)>", match.group(1))
 
-if __name__ == "__main__":
-    client = ICTVOLSClient("http://localhost:8080/api/v2/ontologies/ictv_all_versions")
-
-    G = client.get_history_graph('MSL6', 'Bovine adenovirus')
-    pos = nx.spring_layout(G)
-    nx.draw(G, pos, with_labels=True, node_color='skyblue', node_size=2000, edge_color='gray', font_size=14, font_weight='bold', labels=nx.get_node_attributes(G, 'label'))
-    plt.title("Graph Visualization")
-    plt.show()
-
-    
-    #print(client.get_replacements('MSL7', 'Cardiovirus'))
+    def _ttl_prefixed_iri(self, block: str, predicate: str) -> Optional[str]:
+        match = re.search(rf"{re.escape(predicate)}\s+([a-z]+):(\d+)", block)
+        if not match:
+            return None
+        prefix, local = match.groups()
+        if prefix == "iao":
+            return f"http://purl.obolibrary.org/obo/IAO_{local}"
+        return f"{prefix}:{local}"
 
 
+ICTVtoNCBImapping = _helper.ICTVtoNCBImapping
 
-
+__all__ = ["ICTVOLSClient", "ICTVtoNCBImapping"]


### PR DESCRIPTION
This restores the original ICTV notebook examples while adapting their backing helper to current OLS behavior.

The notebook-facing `ictv_ols.py` now delegates normal lookups to the maintained Python helper and keeps the original example method names. Release-specific examples still use `owl:versionInfo` as the authoritative release field; when the live OLS v2 property filter returns no usable results, the notebook falls back to the ontology file advertised by OLS metadata and filters release terms locally.

The notebook was re-executed successfully with Docker.